### PR TITLE
Move dependencies to requirements file and improve the readme file

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,51 +1,42 @@
-# sns-weka-prometheus
-Weka Prometheus Client v1.2.2
+# Weka Metrics Exporter
 
-Prometheus Client for WekaFS.  Gathers statistics from a Weka Cluster and publishes so Prometheus can scrape it.
+Metrics exporter for WekaFS. Gathers metrics and statistics from a Weka Cluster and exposes a metrics endpoint for Prometheus to scrape.
 
-Installation:
+## Installation
 
-    1. unpack tarball (I guess you've done that already! ;) )
-    2. pip install prometheus_client (you might have to yum install python2-pip first)
-    3. pip install pyyaml
+1. Unpack tarball or clone repository.
+2. Make sure you have Python 3.5+ and `pip` installed on you machine.
+3. Install package dependencies: `pip install -r requirements.txt`.
 
-if you don't have prometheus and grafana already:
-    4. Configure prometheus to pull data from the weka prometheus client (see prometheus docs) 
-          example snippet from prometheus.yml:
+## Metrics Exported
 
-          # weka
-          - job_name: 'weka'
-            scrape_interval:     60s
-            static_configs:
-            - targets: ['localhost:8000']
+1. Edit the weka-metrics-exporter.yaml file. All the metrics that can be collected are defined there. Note that the default contents are sufficient to populate the example dashboards. **Add ONLY what you need**. It does generate load on the cluster to collects these stats.
+2. Uncomment any metrics you would like to gather that are commented out. Restart the exporter to start gathering those metrics.
+3. To display new metrics in Grafana, add new panel(s) and query. Try to curl the data from the metrics endpoint.
 
-    5. Configure Grafana to pull data from prometheus (see grafana docs)
+## Usage
 
-    6. Import the included dashboards (.json files) into grafana
-    7. run weka_prom_client.py
-        Typical command-line:   nohup ./weka_prom_client.py -a -H <target host> &
+Configure prometheus to pull data from the Weka metrics exporter (see prometheus docs). Example Prometheus configuration:
 
-        get help with:
-        ./weka_prom_client.py -h
+```
+# Weka
+- job_name: 'weka'
+  scrape_interval: 60s
+  static_configs:
+    - targets: ['localhost:8000']
+```
 
-OPTIONAL:
-    1. Edit the weka_prom.yaml file.   All the metrics that can be collected are defined there.  
-        - Note that the contents of the .yaml are sufficient to populate the example dashboards
-        - add ONLY what you need.  It does generate load on the cluster to collects these stats
-    2. Uncomment any metrics you would like to gather that are commented out.  Restart the weka_prom_client.py
-        to start gathering those metrics.
-    3. To display new metrics in Grafana, add new panel(s) and query.   Try to curl the data from the weka_prom_client.py
-        - to view what they look like: curl http://localhost:8000 (or whatever you set it to)
+*Important*: Currently the exporter pulls stats every 60 seconds so there is no use of setting the interval to a lower value.
 
+It is recommended to be run as a daemon: `nohup ./weka-metrics-exporter.py -a -H <target host> &`. or better, run as a system service.
 
-suggestions:
-    1. use the -a option to load-balance the data collection over all the weka backends
-    2. use -H hostname as needed (for example, if you're not running this on a client or backend)
-    3. -p port sets the port number - Default port is 8000
-        - ie: http://localhost:8000
-    4. You can test with it in the foreground, but "nohup ./weka_prometheus_client.py -a &" is suggested, or
-        better yet, set it up as a service
-            - Someday we'll include the scripts for the service
+## Configuration
 
-Comments, issues, etc to vince@weka.io
+- Use the `-a` option to load-balance the data collection over all the Weka backends.
+- Use `-H` hostname as needed (for example, if you're not running this on a client or backend).
+- `-p` port sets the port number - Default port is 8000
+- `-h` will print the help message.
 
+Comments, issues, etc can be reported in the repository's issues.
+
+Maintained by vince@weka.io

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+prometheus_client==0.8.0
+pyyaml==5.3.1


### PR DESCRIPTION
This makes it easier to install dependencies. I also pinned the packages to their current versions so that they wouldn't update and break anything.

I also reformatted the readme file so it will look nicer on Github.
Finally, I removed the exporter former version. In Git you can retrieve old versions by checking out to an older commit. There is no reason to keep it.